### PR TITLE
Added write to file for ZSTD compression.

### DIFF
--- a/src/pilgrim_timings.c
+++ b/src/pilgrim_timings.c
@@ -807,7 +807,6 @@ void write_zstd_timings(RecordHash* cst, int mpi_rank, int mpi_size,
     LL_COUNT(g_durations, elt, local_total);
 
     double *local_durations = pilgrim_malloc(sizeof(double) * local_total);
-    double *local_intervals = pilgrim_malloc(sizeof(double) * local_total);
 
     int i = 0;
     LL_FOREACH_SAFE(g_durations, elt, tmp2) {
@@ -818,11 +817,10 @@ void write_zstd_timings(RecordHash* cst, int mpi_rank, int mpi_size,
     void* buff = pilgrim_malloc(buff_size);
 
     size_t compressed_bytes = ZSTD_compress(buff, buff_size, local_durations, local_total*sizeof(double), 1);
-
+	dump_timings(buff, compressed_bytes, dur_path);
     pilgrim_free(buff, buff_size);
 
     pilgrim_free(local_durations, sizeof(double)*local_total);
-    pilgrim_free(local_intervals, sizeof(double)*local_total);
 
     PMPI_Barrier(MPI_COMM_WORLD);
     printf("ZSTD compression ratio: %f\n", (1.0*local_total/compressed_bytes*sizeof(double)));


### PR DESCRIPTION
In the `write_zstd_timings` function, the timestamps were being compressed but never written to a file. This fixes it. It also removes the `malloc` calls to create `local_interval`, since it was unused.