### PR TITLE
Code cleaning

### DIFF
--- a/include/pilgrim.h
+++ b/include/pilgrim.h
@@ -24,11 +24,11 @@
         return res;                                                                     \
     }                                                                                   \
     short func_id = ID_##func;                                                          \
-    double tstart = pilgrim_wtime() - g_program_start_time;                             \
+    double tstart = pilgrim_wtime() - logger_get_program_start_time();                  \
     set_inside_mpi();                                                                   \
     ret_type res = P##func func_args;                                                   \
     unset_inside_mpi();                                                                 \
-    double tend = pilgrim_wtime() - g_program_start_time;
+    double tend = pilgrim_wtime() - logger_get_program_start_time();
 
 
 // Then in a Record structure and write it to log

--- a/include/pilgrim_consts.h
+++ b/include/pilgrim_consts.h
@@ -5,8 +5,12 @@
 #include "pilgrim_reader.h"
 
 #if MPI_VERSION >= 3
+#ifndef MPI_LB
 #define MPI_LB MPI_DATATYPE_NULL
+#endif
+#ifndef MPI_UB
 #define MPI_UB MPI_DATATYPE_NULL
+#endif
 #endif
 
 

--- a/include/pilgrim_consts.h
+++ b/include/pilgrim_consts.h
@@ -4,13 +4,14 @@
 #include <mpi.h>
 #include "pilgrim_reader.h"
 
+// MPI_LB and MPI_UB are deprecated with MPI 3.0 and above.
+// OpenMPI define them to report errors. Here, we override
+// them to avoid the compile time error.
 #if MPI_VERSION >= 3
-#ifndef MPI_LB
+#undef MPI_LB
+#undef MPI_UB
 #define MPI_LB MPI_DATATYPE_NULL
-#endif
-#ifndef MPI_UB
 #define MPI_UB MPI_DATATYPE_NULL
-#endif
 #endif
 
 

--- a/include/pilgrim_logger.h
+++ b/include/pilgrim_logger.h
@@ -13,12 +13,6 @@
 #define PILGRIM_TRACING_MODE_ONDEMAND "DYNAMIC"
 
 
-// Global variables
-static int g_mpi_rank;
-static int g_mpi_size;
-static double g_program_start_time;
-
-
 // Store a list of lossless duration or interval
 typedef struct TimingNode_t {
     double val;
@@ -80,11 +74,15 @@ typedef struct _GlobalMetadata {
 } GlobalMetadata;
 
 
-void logger_init();
+void logger_init(int mpi_rank, int mpi_size);
 void logger_exit();
 bool logger_initialized();
 void logger_recording_on();
 void logger_recording_off();
+
+int  logger_get_mpi_rank();
+int  logger_get_mpi_size();
+double logger_get_program_start_time();
 
 void* compose_call_signature(Record *record, int *key_len);
 void write_record(Record record);

--- a/include/pilgrim_logger.h
+++ b/include/pilgrim_logger.h
@@ -14,9 +14,9 @@
 
 
 // Global variables
-int g_mpi_rank;
-int g_mpi_size;
-double g_program_start_time;
+static int g_mpi_rank;
+static int g_mpi_size;
+static double g_program_start_time;
 
 
 // Store a list of lossless duration or interval

--- a/include/pilgrim_mem_hooks.h
+++ b/include/pilgrim_mem_hooks.h
@@ -15,18 +15,11 @@ typedef struct MemPtrAttr_t {
 } MemPtrAttr;
 
 
-static int g_inside_mpi;
-
 void install_mem_hooks();
 void uninstall_mem_hooks();
 void addr2id(const void *buffer, MemPtrAttr *mem_attr);
 
-
-static void set_inside_mpi() {
-    g_inside_mpi = 1;
-}
-static void unset_inside_mpi() {
-    g_inside_mpi = 0;
-}
+void set_inside_mpi();
+void unset_inside_mpi();
 
 #endif

--- a/include/pilgrim_mem_hooks.h
+++ b/include/pilgrim_mem_hooks.h
@@ -15,8 +15,7 @@ typedef struct MemPtrAttr_t {
 } MemPtrAttr;
 
 
-int g_inside_mpi;
-
+static int g_inside_mpi;
 
 void install_mem_hooks();
 void uninstall_mem_hooks();

--- a/include/pilgrim_pthread_hooks.h
+++ b/include/pilgrim_pthread_hooks.h
@@ -6,47 +6,7 @@
 #ifndef _PILGRIM_PTHREAD_HOOKS_H_
 #define _PILGRIM_PTHREAD_HOOKS_H_
 
-#define _GNU_SOURCE
-#include <stdio.h>
 #include <pthread.h>
-#include <dlfcn.h>
-
-
-/*
- * Declare the function signatures for real functions
- * i.e. The real function point to fwrite would be defined as __real_fwrite
- */
-#define PILGRIM_REAL_DECL(name, ret, args) ret (*__real_##name) args;
-
-/* Point __real_func to the real funciton using dlsym() */
-#define MAP_OR_FAIL(func)                                                   \
-    if (!(__real_##func)) {                                                 \
-        __real_##func = dlsym(RTLD_NEXT, #func);                            \
-        if (!(__real_##func)) {                                             \
-            printf("Recorder failed to map symbol: %s\n", #func);           \
-        }                                                                   \
-    }
-
-/*
- * Call the real funciton
- * Before call the real function, we need to make sure its mapped by dlsym()
- * So, every time we use this marco directly, we need to call MAP_OR_FAIL before it
- */
-#define PILGRIM_REAL_CALL(func) __real_##func
-
-PILGRIM_REAL_DECL(pthread_create, int, (pthread_t *thread, const pthread_attr_t *attr, void *(*start_routine)(void*), void *arg));
-PILGRIM_REAL_DECL(pthread_exit, void, (void *value_ptr));
-PILGRIM_REAL_DECL(pthread_join, int, (pthread_t thread, void *value_ptr));
-PILGRIM_REAL_DECL(pthread_detach, int, (pthread_t thread));
-
-PILGRIM_REAL_DECL(pthread_mutex_init, int, (pthread_mutex_t *, const pthread_mutexattr_t *));
-PILGRIM_REAL_DECL(pthread_rwlock_init, int, (pthread_rwlock_t *, const pthread_rwlockattr_t *));
-PILGRIM_REAL_DECL(pthread_cond_init, int, (pthread_cond_t *, const pthread_condattr_t *));
-PILGRIM_REAL_DECL(pthread_cond_wait, int, (pthread_cond_t *cond, pthread_mutex_t *mutex));
-PILGRIM_REAL_DECL(pthread_cond_timedwait, int, (pthread_cond_t *cond, pthread_mutex_t *mutex, const struct timespec *abstime));
-PILGRIM_REAL_DECL(pthread_mutex_lock, int, (pthread_mutex_t *mutex));
-PILGRIM_REAL_DECL(pthread_mutex_unlock, int, (pthread_mutex_t *mutex));
-PILGRIM_REAL_DECL(pthread_mutex_trylock, int, (pthread_mutex_t *mutex));
 
 // Get the symbolic id of pthread_t
 int pilgrim_pthread_add_get_tid();

--- a/src/pilgrim_init_finalize.c
+++ b/src/pilgrim_init_finalize.c
@@ -12,10 +12,11 @@ double tstart, tend, tmin, tmax;
 double elapsed_time;
 
 void pilgrim_init(int *argc, char ***argv) {
-    PMPI_Comm_size(MPI_COMM_WORLD, &g_mpi_size);
-    PMPI_Comm_rank(MPI_COMM_WORLD, &g_mpi_rank);
+    int mpi_rank, mpi_size;
+    PMPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
+    PMPI_Comm_size(MPI_COMM_WORLD, &mpi_size);
 
-    logger_init();
+    logger_init(mpi_rank, mpi_size);
     elapsed_time = pilgrim_wtime();
     tstart = pilgrim_wtime();
 }

--- a/src/pilgrim_logger.c
+++ b/src/pilgrim_logger.c
@@ -475,7 +475,7 @@ void* compose_call_signature(Record *record, int *key_len) {
 void write_record(Record record) {
     if (!__logger.recording) return;
 
-    PILGRIM_REAL_CALL(pthread_mutex_lock)(&g_mutex);
+    pthread_mutex_lock(&g_mutex);
 
     /*
     if(__logger.rank == 0)
@@ -555,7 +555,7 @@ void write_record(Record record) {
     // Grow the MPI call grammar
     append_terminal(&(__logger.grammar), entry->terminal_id, 1);
 
-    PILGRIM_REAL_CALL(pthread_mutex_unlock)(&g_mutex);
+    pthread_mutex_unlock(&g_mutex);
 }
 
 void logger_init() {
@@ -625,8 +625,6 @@ void logger_init() {
         sequitur_init(&(__logger.durations_grammar));
     }
 
-    MAP_OR_FAIL(pthread_mutex_lock);
-    MAP_OR_FAIL(pthread_mutex_unlock);
     install_mem_hooks();
 
     __logger.initialized = true;

--- a/src/pilgrim_logger.c
+++ b/src/pilgrim_logger.c
@@ -558,13 +558,12 @@ void write_record(Record record) {
     pthread_mutex_unlock(&g_mutex);
 }
 
-void logger_init() {
-    g_program_start_time = pilgrim_wtime();
-    __logger.rank = g_mpi_rank;
-    __logger.nprocs = g_mpi_size;
-    __logger.local_metadata.tstart = g_program_start_time;
+void logger_init(int mpi_rank, int mpi_size) {
+    __logger.rank = mpi_rank;
+    __logger.nprocs = mpi_size;
+    __logger.local_metadata.tstart = pilgrim_wtime();
     __logger.local_metadata.records_count = 0;
-    __logger.local_metadata.rank = g_mpi_rank;
+    __logger.local_metadata.rank = mpi_rank;
     __logger.hash_head   = NULL;          // Must be NULL initialized
     __logger.offset_list = NULL;
     __logger.initialized = false;
@@ -612,7 +611,7 @@ void logger_init() {
         FILE* global_metafh = fopen(METADATA_OUTPUT_PATH, "wb");
         GlobalMetadata global_metadata= {
             .time_resolution = TIME_RESOLUTION,
-            .ranks = g_mpi_size,
+            .ranks = __logger.nprocs,
         };
         strcpy(global_metadata.timing_mode, __logger.timing_mode);
         fwrite(&global_metadata, sizeof(GlobalMetadata), 1, global_metafh);
@@ -722,4 +721,16 @@ void logger_exit() {
     }
 
     free(__logger.timing_mode);
+}
+
+int logger_get_mpi_rank() {
+    return __logger.rank;
+}
+
+int logger_get_mpi_size() {
+    return __logger.nprocs;
+}
+
+double logger_get_program_start_time() {
+    __logger.local_metadata.tstart;
 }

--- a/src/pilgrim_mem_hooks.c
+++ b/src/pilgrim_mem_hooks.c
@@ -41,9 +41,6 @@ pthread_mutex_t avl_lock = PTHREAD_MUTEX_INITIALIZER;
 
 // Three public available function in .h
 void install_mem_hooks() {
-    MAP_OR_FAIL(pthread_mutex_lock);
-    MAP_OR_FAIL(pthread_mutex_unlock);
-
     hook_installed = true;
     cpu_addr_tree = NULL;
     gpu_addr_tree = NULL;
@@ -98,7 +95,7 @@ void addr2id(const void* buffer, MemPtrAttr *mem_attr) {
     mem_attr->type = attr.memoryType;
     mem_attr->device = attr.device;
 
-    PILGRIM_REAL_CALL(pthread_mutex_lock)(&avl_lock);
+    pthread_mutex_lock(&avl_lock);
 
     if(mem_attr->type == 0)      // unregistered memory, which is allocated using malloc()
         avl_node = avl_search(cpu_addr_tree, (intptr_t) buffer);
@@ -140,21 +137,21 @@ void addr2id(const void* buffer, MemPtrAttr *mem_attr) {
     mem_attr->offset = ((intptr_t)buffer) - avl_node->addr;
     mem_attr->size = avl_node->size;
     if(!avl_node->heap) mem_attr->size = 0;   // use size = 0 to tell the post-processing that this is a stack var
-    PILGRIM_REAL_CALL(pthread_mutex_unlock)(&avl_lock);
+    pthread_mutex_unlock(&avl_lock);
 }
 
 // Thread safe insert/delete from addr tree
 void safe_insert_addr(AvlTree *addr_tree, void* ptr, size_t size) {
-    PILGRIM_REAL_CALL(pthread_mutex_lock)(&avl_lock);
+    pthread_mutex_lock(&avl_lock);
     num_malloc++;
     if(g_inside_mpi)
         num_malloc_by_mpi++;
     avl_insert(addr_tree, (intptr_t)ptr, size, true);
-    PILGRIM_REAL_CALL(pthread_mutex_unlock)(&avl_lock);
+    pthread_mutex_unlock(&avl_lock);
 }
 
 void safe_delete_addr(AvlTree *addr_tree, void* ptr) {
-    PILGRIM_REAL_CALL(pthread_mutex_lock)(&avl_lock);
+    pthread_mutex_lock(&avl_lock);
     AvlTree avl_node = avl_search(*addr_tree, (intptr_t)ptr);
     num_free++;
 
@@ -194,7 +191,7 @@ void safe_delete_addr(AvlTree *addr_tree, void* ptr) {
         if(heap)
             dlfree(ptr);
     }
-    PILGRIM_REAL_CALL(pthread_mutex_unlock)(&avl_lock);
+    pthread_mutex_unlock(&avl_lock);
 }
 
 
@@ -226,7 +223,7 @@ void* realloc(void *ptr, size_t size) {
 
     void *new_ptr = dlrealloc(ptr, size);
 
-    PILGRIM_REAL_CALL(pthread_mutex_lock)(&avl_lock);
+    pthread_mutex_lock(&avl_lock);
     if(new_ptr == ptr) {
         AvlTree t = avl_search(cpu_addr_tree, (intptr_t)ptr);
         if(t != AVL_EMPTY) {
@@ -236,7 +233,7 @@ void* realloc(void *ptr, size_t size) {
         avl_delete(&cpu_addr_tree, (intptr_t)ptr);
         avl_insert(&cpu_addr_tree, (intptr_t)new_ptr, size, true);
     }
-    PILGRIM_REAL_CALL(pthread_mutex_unlock)(&avl_lock);
+    pthread_mutex_unlock(&avl_lock);
 
     return new_ptr;
 }

--- a/src/pilgrim_wrappers.c
+++ b/src/pilgrim_wrappers.c
@@ -46,10 +46,10 @@ int c_MPI_Sendrecv_replace(void *buf, int count, MPI_Datatype datatype, int dest
 	addr2id(buf, &mem_attr_0);
 	MPI_Datatype obj_0 = datatype;
 	int obj_id_0 = MPI_OBJ_ID(MPI_Datatype, &obj_0);
-	int dest_rank = g_mpi_rank - dest;
+	int dest_rank = logger_get_mpi_rank() - dest;
 	if(dest == MPI_ANY_SOURCE) dest_rank = PILGRIM_MPI_ANY_SOURCE;
 	if(dest == MPI_PROC_NULL) dest_rank = PILGRIM_MPI_PROC_NULL;
-	int source_rank = g_mpi_rank - source;
+	int source_rank = logger_get_mpi_rank() - source;
 	if(source == MPI_ANY_SOURCE) source_rank = PILGRIM_MPI_ANY_SOURCE;
 	if(source == MPI_PROC_NULL) source_rank = PILGRIM_MPI_PROC_NULL;
 	MPI_Comm obj_1 = comm;
@@ -764,7 +764,7 @@ int c_MPI_Rsend(const void *buf, int count, MPI_Datatype datatype, int dest, int
 	addr2id(buf, &mem_attr_0);
 	MPI_Datatype obj_0 = datatype;
 	int obj_id_0 = MPI_OBJ_ID(MPI_Datatype, &obj_0);
-	int dest_rank = g_mpi_rank - dest;
+	int dest_rank = logger_get_mpi_rank() - dest;
 	if(dest == MPI_ANY_SOURCE) dest_rank = PILGRIM_MPI_ANY_SOURCE;
 	if(dest == MPI_PROC_NULL) dest_rank = PILGRIM_MPI_PROC_NULL;
 	int my_tag = tag;
@@ -1112,7 +1112,7 @@ int c_MPI_Irsend(const void *buf, int count, MPI_Datatype datatype, int dest, in
 	addr2id(buf, &mem_attr_0);
 	MPI_Datatype obj_0 = datatype;
 	int obj_id_0 = MPI_OBJ_ID(MPI_Datatype, &obj_0);
-	int dest_rank = g_mpi_rank - dest;
+	int dest_rank = logger_get_mpi_rank() - dest;
 	if(dest == MPI_ANY_SOURCE) dest_rank = PILGRIM_MPI_ANY_SOURCE;
 	if(dest == MPI_PROC_NULL) dest_rank = PILGRIM_MPI_PROC_NULL;
 	int my_tag = tag;
@@ -1405,7 +1405,7 @@ int c_MPI_Ssend_init(const void *buf, int count, MPI_Datatype datatype, int dest
 	addr2id(buf, &mem_attr_0);
 	MPI_Datatype obj_0 = datatype;
 	int obj_id_0 = MPI_OBJ_ID(MPI_Datatype, &obj_0);
-	int dest_rank = g_mpi_rank - dest;
+	int dest_rank = logger_get_mpi_rank() - dest;
 	if(dest == MPI_ANY_SOURCE) dest_rank = PILGRIM_MPI_ANY_SOURCE;
 	if(dest == MPI_PROC_NULL) dest_rank = PILGRIM_MPI_PROC_NULL;
 	int my_tag = tag;
@@ -1446,7 +1446,7 @@ int c_MPI_Rsend_init(const void *buf, int count, MPI_Datatype datatype, int dest
 	addr2id(buf, &mem_attr_0);
 	MPI_Datatype obj_0 = datatype;
 	int obj_id_0 = MPI_OBJ_ID(MPI_Datatype, &obj_0);
-	int dest_rank = g_mpi_rank - dest;
+	int dest_rank = logger_get_mpi_rank() - dest;
 	if(dest == MPI_ANY_SOURCE) dest_rank = PILGRIM_MPI_ANY_SOURCE;
 	if(dest == MPI_PROC_NULL) dest_rank = PILGRIM_MPI_PROC_NULL;
 	int my_tag = tag;
@@ -1990,7 +1990,7 @@ int c_MPI_Send(const void *buf, int count, MPI_Datatype datatype, int dest, int 
 	addr2id(buf, &mem_attr_0);
 	MPI_Datatype obj_0 = datatype;
 	int obj_id_0 = MPI_OBJ_ID(MPI_Datatype, &obj_0);
-	int dest_rank = g_mpi_rank - dest;
+	int dest_rank = logger_get_mpi_rank() - dest;
 	if(dest == MPI_ANY_SOURCE) dest_rank = PILGRIM_MPI_ANY_SOURCE;
 	if(dest == MPI_PROC_NULL) dest_rank = PILGRIM_MPI_PROC_NULL;
 	int my_tag = tag;
@@ -2590,7 +2590,7 @@ extern void mpi_type_get_extent_x__(MPI_Fint* datatype, MPI_Count* lb, MPI_Count
 int c_MPI_Probe(int source, int tag, MPI_Comm comm, MPI_Status *status)
 {
 	PILGRIM_TRACING_1(int, MPI_Probe, (source, tag, comm, status));
-	int source_rank = g_mpi_rank - source;
+	int source_rank = logger_get_mpi_rank() - source;
 	if(source == MPI_ANY_SOURCE) source_rank = PILGRIM_MPI_ANY_SOURCE;
 	if(source == MPI_PROC_NULL) source_rank = PILGRIM_MPI_PROC_NULL;
 	int my_tag = tag;
@@ -2860,7 +2860,7 @@ int c_MPI_Recv_init(void *buf, int count, MPI_Datatype datatype, int source, int
 	addr2id(buf, &mem_attr_0);
 	MPI_Datatype obj_0 = datatype;
 	int obj_id_0 = MPI_OBJ_ID(MPI_Datatype, &obj_0);
-	int source_rank = g_mpi_rank - source;
+	int source_rank = logger_get_mpi_rank() - source;
 	if(source == MPI_ANY_SOURCE) source_rank = PILGRIM_MPI_ANY_SOURCE;
 	if(source == MPI_PROC_NULL) source_rank = PILGRIM_MPI_PROC_NULL;
 	int my_tag = tag;
@@ -3975,7 +3975,7 @@ int c_MPI_Ibsend(const void *buf, int count, MPI_Datatype datatype, int dest, in
 	addr2id(buf, &mem_attr_0);
 	MPI_Datatype obj_0 = datatype;
 	int obj_id_0 = MPI_OBJ_ID(MPI_Datatype, &obj_0);
-	int dest_rank = g_mpi_rank - dest;
+	int dest_rank = logger_get_mpi_rank() - dest;
 	if(dest == MPI_ANY_SOURCE) dest_rank = PILGRIM_MPI_ANY_SOURCE;
 	if(dest == MPI_PROC_NULL) dest_rank = PILGRIM_MPI_PROC_NULL;
 	int my_tag = tag;
@@ -4518,7 +4518,7 @@ int c_MPI_Send_init(const void *buf, int count, MPI_Datatype datatype, int dest,
 	addr2id(buf, &mem_attr_0);
 	MPI_Datatype obj_0 = datatype;
 	int obj_id_0 = MPI_OBJ_ID(MPI_Datatype, &obj_0);
-	int dest_rank = g_mpi_rank - dest;
+	int dest_rank = logger_get_mpi_rank() - dest;
 	if(dest == MPI_ANY_SOURCE) dest_rank = PILGRIM_MPI_ANY_SOURCE;
 	if(dest == MPI_PROC_NULL) dest_rank = PILGRIM_MPI_PROC_NULL;
 	int my_tag = tag;
@@ -7031,7 +7031,7 @@ extern void mpi_comm_get_errhandler__(MPI_Fint* comm, MPI_Fint* errhandler, MPI_
 int c_MPI_Mprobe(int source, int tag, MPI_Comm comm, MPI_Message *message, MPI_Status *status)
 {
 	PILGRIM_TRACING_1(int, MPI_Mprobe, (source, tag, comm, message, status));
-	int source_rank = g_mpi_rank - source;
+	int source_rank = logger_get_mpi_rank() - source;
 	if(source == MPI_ANY_SOURCE) source_rank = PILGRIM_MPI_ANY_SOURCE;
 	if(source == MPI_PROC_NULL) source_rank = PILGRIM_MPI_PROC_NULL;
 	int my_tag = tag;
@@ -8478,7 +8478,7 @@ int c_MPI_Recv(void *buf, int count, MPI_Datatype datatype, int source, int tag,
 	addr2id(buf, &mem_attr_0);
 	MPI_Datatype obj_0 = datatype;
 	int obj_id_0 = MPI_OBJ_ID(MPI_Datatype, &obj_0);
-	int source_rank = g_mpi_rank - source;
+	int source_rank = logger_get_mpi_rank() - source;
 	if(source == MPI_ANY_SOURCE) source_rank = PILGRIM_MPI_ANY_SOURCE;
 	if(source == MPI_PROC_NULL) source_rank = PILGRIM_MPI_PROC_NULL;
 	int my_tag = tag;
@@ -8627,7 +8627,7 @@ int c_MPI_Bsend(const void *buf, int count, MPI_Datatype datatype, int dest, int
 	addr2id(buf, &mem_attr_0);
 	MPI_Datatype obj_0 = datatype;
 	int obj_id_0 = MPI_OBJ_ID(MPI_Datatype, &obj_0);
-	int dest_rank = g_mpi_rank - dest;
+	int dest_rank = logger_get_mpi_rank() - dest;
 	if(dest == MPI_ANY_SOURCE) dest_rank = PILGRIM_MPI_ANY_SOURCE;
 	if(dest == MPI_PROC_NULL) dest_rank = PILGRIM_MPI_PROC_NULL;
 	int my_tag = tag;
@@ -8711,7 +8711,7 @@ int c_MPI_Irecv(void *buf, int count, MPI_Datatype datatype, int source, int tag
 	addr2id(buf, &mem_attr_0);
 	MPI_Datatype obj_0 = datatype;
 	int obj_id_0 = MPI_OBJ_ID(MPI_Datatype, &obj_0);
-	int source_rank = g_mpi_rank - source;
+	int source_rank = logger_get_mpi_rank() - source;
 	if(source == MPI_ANY_SOURCE) source_rank = PILGRIM_MPI_ANY_SOURCE;
 	if(source == MPI_PROC_NULL) source_rank = PILGRIM_MPI_PROC_NULL;
 	int my_tag = tag;
@@ -8753,7 +8753,7 @@ int c_MPI_Issend(const void *buf, int count, MPI_Datatype datatype, int dest, in
 	addr2id(buf, &mem_attr_0);
 	MPI_Datatype obj_0 = datatype;
 	int obj_id_0 = MPI_OBJ_ID(MPI_Datatype, &obj_0);
-	int dest_rank = g_mpi_rank - dest;
+	int dest_rank = logger_get_mpi_rank() - dest;
 	if(dest == MPI_ANY_SOURCE) dest_rank = PILGRIM_MPI_ANY_SOURCE;
 	if(dest == MPI_PROC_NULL) dest_rank = PILGRIM_MPI_PROC_NULL;
 	int my_tag = tag;
@@ -9501,14 +9501,14 @@ int c_MPI_Sendrecv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, in
 	addr2id(sendbuf, &mem_attr_0);
 	MPI_Datatype obj_0 = sendtype;
 	int obj_id_0 = MPI_OBJ_ID(MPI_Datatype, &obj_0);
-	int dest_rank = g_mpi_rank - dest;
+	int dest_rank = logger_get_mpi_rank() - dest;
 	if(dest == MPI_ANY_SOURCE) dest_rank = PILGRIM_MPI_ANY_SOURCE;
 	if(dest == MPI_PROC_NULL) dest_rank = PILGRIM_MPI_PROC_NULL;
 	MemPtrAttr mem_attr_1;
 	addr2id(recvbuf, &mem_attr_1);
 	MPI_Datatype obj_1 = recvtype;
 	int obj_id_1 = MPI_OBJ_ID(MPI_Datatype, &obj_1);
-	int source_rank = g_mpi_rank - source;
+	int source_rank = logger_get_mpi_rank() - source;
 	if(source == MPI_ANY_SOURCE) source_rank = PILGRIM_MPI_ANY_SOURCE;
 	if(source == MPI_PROC_NULL) source_rank = PILGRIM_MPI_PROC_NULL;
 	MPI_Comm obj_2 = comm;
@@ -9934,7 +9934,7 @@ int c_MPI_Isend(const void *buf, int count, MPI_Datatype datatype, int dest, int
 	addr2id(buf, &mem_attr_0);
 	MPI_Datatype obj_0 = datatype;
 	int obj_id_0 = MPI_OBJ_ID(MPI_Datatype, &obj_0);
-	int dest_rank = g_mpi_rank - dest;
+	int dest_rank = logger_get_mpi_rank() - dest;
 	if(dest == MPI_ANY_SOURCE) dest_rank = PILGRIM_MPI_ANY_SOURCE;
 	if(dest == MPI_PROC_NULL) dest_rank = PILGRIM_MPI_PROC_NULL;
 	int my_tag = tag;
@@ -10396,7 +10396,7 @@ extern void mpi_get__(void* origin_addr, int* origin_count, MPI_Fint* origin_dat
 int c_MPI_Iprobe(int source, int tag, MPI_Comm comm, int *flag, MPI_Status *status)
 {
 	PILGRIM_TRACING_1(int, MPI_Iprobe, (source, tag, comm, flag, status));
-	int source_rank = g_mpi_rank - source;
+	int source_rank = logger_get_mpi_rank() - source;
 	if(source == MPI_ANY_SOURCE) source_rank = PILGRIM_MPI_ANY_SOURCE;
 	if(source == MPI_PROC_NULL) source_rank = PILGRIM_MPI_PROC_NULL;
 	int my_tag = tag;
@@ -10528,7 +10528,7 @@ extern void mpi_win_detach__(MPI_Fint* win, const void* base, MPI_Fint *ierr) {
 int c_MPI_Improbe(int source, int tag, MPI_Comm comm, int *flag, MPI_Message *message, MPI_Status *status)
 {
 	PILGRIM_TRACING_1(int, MPI_Improbe, (source, tag, comm, flag, message, status));
-	int source_rank = g_mpi_rank - source;
+	int source_rank = logger_get_mpi_rank() - source;
 	if(source == MPI_ANY_SOURCE) source_rank = PILGRIM_MPI_ANY_SOURCE;
 	if(source == MPI_PROC_NULL) source_rank = PILGRIM_MPI_PROC_NULL;
 	int my_tag = tag;
@@ -10574,7 +10574,7 @@ int c_MPI_Ssend(const void *buf, int count, MPI_Datatype datatype, int dest, int
 	addr2id(buf, &mem_attr_0);
 	MPI_Datatype obj_0 = datatype;
 	int obj_id_0 = MPI_OBJ_ID(MPI_Datatype, &obj_0);
-	int dest_rank = g_mpi_rank - dest;
+	int dest_rank = logger_get_mpi_rank() - dest;
 	if(dest == MPI_ANY_SOURCE) dest_rank = PILGRIM_MPI_ANY_SOURCE;
 	if(dest == MPI_PROC_NULL) dest_rank = PILGRIM_MPI_PROC_NULL;
 	int my_tag = tag;
@@ -10840,7 +10840,7 @@ int c_MPI_Bsend_init(const void *buf, int count, MPI_Datatype datatype, int dest
 	addr2id(buf, &mem_attr_0);
 	MPI_Datatype obj_0 = datatype;
 	int obj_id_0 = MPI_OBJ_ID(MPI_Datatype, &obj_0);
-	int dest_rank = g_mpi_rank - dest;
+	int dest_rank = logger_get_mpi_rank() - dest;
 	if(dest == MPI_ANY_SOURCE) dest_rank = PILGRIM_MPI_ANY_SOURCE;
 	if(dest == MPI_PROC_NULL) dest_rank = PILGRIM_MPI_PROC_NULL;
 	int my_tag = tag;

--- a/src/pilgrim_wrappers_special.c
+++ b/src/pilgrim_wrappers_special.c
@@ -107,9 +107,9 @@ bool is_completed_idup_request(MPI_Request *req) {
     if(flag) {                                                      \
         if(entry && status && status != MPI_STATUS_IGNORE) {        \
             if(entry->any_source)                                   \
-                status_info[0] = g_mpi_rank - status->MPI_SOURCE;   \
+                status_info[0] = logger_get_mpi_rank() - status->MPI_SOURCE;   \
             if(entry->any_tag)                                      \
-                status_info[1] = g_mpi_rank - status->MPI_TAG;      \
+                status_info[1] = logger_get_mpi_rank() - status->MPI_TAG;      \
         }                                                           \
         /* Only when new request is set to NULL */                  \
         /* we can free the object. This is necessary */             \
@@ -133,9 +133,9 @@ bool is_completed_idup_request(MPI_Request *req) {
             entry = request_hash_entry(&old_reqs[iidx]);                                            \
             if(entry && statuses && statuses != MPI_STATUSES_IGNORE) {                              \
                 if(entry->any_source)                                                               \
-                    statuses_info[idx*2+0] = g_mpi_rank-statuses[idx].MPI_SOURCE;                   \
+                    statuses_info[idx*2+0] = logger_get_mpi_rank()-statuses[idx].MPI_SOURCE;                   \
                 if(entry->any_tag)                                                                  \
-                    statuses_info[idx*2+1] = g_mpi_rank-statuses[idx].MPI_TAG;                      \
+                    statuses_info[idx*2+1] = logger_get_mpi_rank()-statuses[idx].MPI_TAG;                      \
             }                                                                                       \
             MPI_OBJ_RELEASE(MPI_Request, &(old_reqs[iidx]));                                        \
         }                                                                                           \
@@ -422,12 +422,12 @@ int imp_MPI_Info_set(MPI_Info info, const char *key, const char *value)
 {
     if(strcmp(key, "PILGRIM_TRACING") == 0) {
         if(strcmp(value, "ON") == 0) {
-            if(g_mpi_rank == 0)
+            if(logger_get_mpi_rank() == 0)
                 printf("[pilgrim] pilgrim tracing on.\n");
             logger_recording_on();
         }
         if(strcmp(value, "OFF") == 0) {
-            if(g_mpi_rank == 0)
+            if(logger_get_mpi_rank() == 0)
                 printf("[pilgrim] pilgrim tracing off.\n");
             logger_recording_off();
         }
@@ -570,7 +570,7 @@ int imp_MPI_Comm_split(MPI_Comm comm, int color, int key, MPI_Comm *newcomm)
 	PILGRIM_TRACING_2(4, sizes, args, -1);
 }
 int MPI_Comm_split(MPI_Comm comm, int color, int key, MPI_Comm *newcomm) { return imp_MPI_Comm_split(comm, color, key, newcomm); }
-extern void f_mpi_comm_split(MPI_Fint* comm, int* color, int* key, MPI_Fint* newcomm, MPI_Fint *ierr) { 
+extern void f_mpi_comm_split(MPI_Fint* comm, int* color, int* key, MPI_Fint* newcomm, MPI_Fint *ierr) {
     MPI_Comm c_comm;
     imp_MPI_Comm_split(PMPI_Comm_f2c(*comm), (*color), (*key), &c_comm);
     *newcomm = PMPI_Comm_c2f(c_comm);
@@ -578,7 +578,7 @@ extern void f_mpi_comm_split(MPI_Fint* comm, int* color, int* key, MPI_Fint* new
 extern void MPI_COMM_SPLIT(MPI_Fint* comm, int* color, int* key, MPI_Fint* newcomm, MPI_Fint *ierr) {
     f_mpi_comm_split(comm, color, key, newcomm, ierr);
 }
-extern void mpi_comm_split(MPI_Fint* comm, int* color, int* key, MPI_Fint* newcomm, MPI_Fint *ierr) { 
+extern void mpi_comm_split(MPI_Fint* comm, int* color, int* key, MPI_Fint* newcomm, MPI_Fint *ierr) {
     f_mpi_comm_split(comm, color, key, newcomm, ierr);
 }
 extern void mpi_comm_split_(MPI_Fint* comm, int* color, int* key, MPI_Fint* newcomm, MPI_Fint *ierr) {


### PR DESCRIPTION
1. Remove unused pthread wrappers.
2. Get rid of several global variables (they may cause compile time errors).
3. Override MPI_LB and MPI_UB to avoid compile time warnings.